### PR TITLE
Added more iso messages.

### DIFF
--- a/iso_msgs/CMakeLists.txt
+++ b/iso_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(builtin_interfaces REQUIRED)
 
 set(msg_files
   "msg/CoordinateSystem.msg"
+  "msg/ObjectState.msg"
   "msg/ObjectSettings.msg"
   "msg/CartesianTrajectory.msg"
   "msg/CartesianTrajectoryPoint.msg"
@@ -27,6 +28,8 @@ set(msg_files
   "msg/OSEMTimeServer.msg"
   "msg/TrajectoryHeader.msg"
   "msg/TrajectoryInfo.msg"
+  "msg/Abort.msg"
+  "msg/Start.msg"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/iso_msgs/msg/Abort.msg
+++ b/iso_msgs/msg/Abort.msg
@@ -1,0 +1,1 @@
+string TOPIC_NAME = "iso22133_abort"

--- a/iso_msgs/msg/ObjectState.msg
+++ b/iso_msgs/msg/ObjectState.msg
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+uint8 STATE_UNKNOWN=0
+uint8 STATE_INIT=1
+uint8 STATE_DISARMED=2
+uint8 STATE_ARMED=3
+uint8 STATE_RUNNING=4
+uint8 STATE_POSTRUN=5
+uint8 STATE_ABORTING=6
+uint8 STATE_REMOTE_CONTROL=7
+uint8 STATE_PRE_ARMING=8
+uint8 STATE_PRE_RUNNING=9
+uint8 state

--- a/iso_msgs/msg/Start.msg
+++ b/iso_msgs/msg/Start.msg
@@ -1,0 +1,1 @@
+string TOPIC_NAME = "iso22133_start"


### PR DESCRIPTION
Added iso messages with for two central state triggers, start and abort, as well as a copy of the ObjectState message in [atos_interfaces](https://github.com/RI-SE/atos_interfaces/blob/master/msg/ObjectState.msg) (not used yet).